### PR TITLE
Improvements to Gradle Configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,41 +1,49 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-	kotlin("jvm") version "1.6.21"
+	id("xyz.jpenilla.run-paper") version "1.0.6"
+	id("org.jetbrains.kotlin.jvm") version "1.6.21"
 	id("io.papermc.paperweight.userdev") version "1.3.6"
 	id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://repo.aikar.co/content/groups/aikar/") }
-	maven { url = uri("https://papermc.io/repo/repository/maven-public/") }
+
+	maven("https://repo.aikar.co/content/groups/aikar/") // acf-paper
 }
 
 dependencies {
-	implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
-
-	compileOnly("io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT")
 	paperDevBundle("1.18.2-R0.1-SNAPSHOT")
-}
 
-java {
-	toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-	kotlinOptions {
-		jvmTarget = "17"
-		javaParameters = true // https://github.com/aikar/commands/wiki/Gradle-Setup
-	}
+	implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
 }
 
 tasks{
+	compileJava {
+		options.compilerArgs.add("-parameters")
+		options.isFork = true
+	}
+
 	build {
 		dependsOn(reobfJar)
 	}
+
 	reobfJar {
 		outputJar.set(file(rootProject.projectDir.absolutePath + "/build/Hydrazine.jar"))
 	}
+
+	shadowJar {
+		relocate("co.aikar.commands", "io.github.hydrazinemc.hydrazine.libraries.co.aikar.commands")
+		relocate("co.aikar.locales", "io.github.hydrazinemc.hydrazine.libraries.co.aikar.locales")
+	}
+
+	compileKotlin {
+		kotlinOptions.javaParameters = true
+		kotlinOptions.jvmTarget = "17"
+	}
+
+	runServer {
+		minecraftVersion("1.18.2")
+	}
 }
 
+java { toolchain.languageVersion.set(JavaLanguageVersion.of(17)) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel = true
+kotlin.incremental = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
 	repositories {
 		gradlePluginPortal()
-		maven("https://papermc.io/repo/repository/maven-public/")
+		maven("https://papermc.io/repo/repository/maven-public/") // paper-api, paperweight-userdev
 	}
 }
 


### PR DESCRIPTION
This PR makes a number of improvements to the gradle configuration, all of which are listed below:
- Added run-paper, a gradle plugin for quickly running a test server ideal for debugging
- Remove PaperMC Maven Repository from build.gradle.kts as it is already listed in settings.gradle.kts
- Used shorthand for defining the Aikar Maven Repository
- Removed paper-api compileOnly as this is added by paperDevBundle
- Set proper compileJava and compileKotlin options for ACF
- ShadowJar Relocated ACF
- Added extra gradle options that should help with build time
- Added comments to indicate what each repository is used for